### PR TITLE
Implemented Feature which enable Connector to leverage Responses

### DIFF
--- a/types/invoker_test.go
+++ b/types/invoker_test.go
@@ -4,7 +4,7 @@
 package types
 
 import (
-	"bytes"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -16,30 +16,66 @@ func TestInvoker_Invoke(t *testing.T) {
 		function := strings.Split(r.URL.Path, "/")[2]
 
 		switch function {
-		case "200":
-			w.Header().Set("Access-Control-Allow-Origin", "*")
+		case "success":
 			w.Header().Set("Content-Type", "text/plain")
 			w.WriteHeader(200)
 			w.Write([]byte("Hello World"))
-		case "401":
+			break
+		case "headers":
 			w.Header().Set("Access-Control-Allow-Origin", "*")
-			w.Header().Set("Content-Type", "text/plain")
-			w.WriteHeader(401)
+			w.Header().Set("Content-Type", "text/html")
+			w.Header().Set("Charset", "utf-8")
+			w.WriteHeader(200)
+			w.Write([]byte("<h1>Hello World</h1>"))
+			break
+		case "wrong_payload":
+			w.WriteHeader(400)
 			w.Write([]byte(""))
-		case "500":
+			break
+		case "aborts":
+			if wr, ok := w.(http.Hijacker); ok {
+				conn, _, err := wr.Hijack()
+				if err != nil{
+					fmt.Printf("Recieved %s",err)
+				}else{
+					conn.Close()
+				}
+
+			}
+			break
+		case "server_error":
+			w.WriteHeader(500)
+			w.Write([]byte(""))
+			break
 		}
-		w.WriteHeader(500)
 	}))
+
 	client := srv.Client()
 	topicMap := NewTopicMap()
+
 	sampleFunc := map[string][]string{
-		"Success":        []string{"200"},
-		"UnAuthorized":   []string{"401"},
-		"Internal Error": []string{"500"},
+		"All":        []string{"success", "headers", "wrong_payload"},
+		"Contains_Fail":   []string{"success", "server_error", "aborts", "headers"},
+		"NOP": []string{},
 	}
+
 	topicMap.Sync(&sampleFunc)
 
-	t.Run("Empty Body", func(t *testing.T) {
+	t.Run("Should invoke no function when body is nil", func(t *testing.T) {
+		target := &Invoker{
+			PrintResponse:false,
+			Client:client,
+			GatewayURL: srv.URL,
+		}
+
+		results := target.Invoke(&topicMap, "NOP", nil)
+
+		if len(results) != 0 {
+			t.Errorf("When body is nil it should perform a request")
+		}
+	})
+
+	t.Run("Should invoke no function when body is empty", func(t *testing.T) {
 		target := &Invoker{
 			true,
 			client,
@@ -47,100 +83,65 @@ func TestInvoker_Invoke(t *testing.T) {
 		}
 
 		body := []byte("")
-		results := target.Invoke(&topicMap, "Success", &body)
+		results := target.Invoke(&topicMap, "NOP", &body)
 
 		if len(results) != 0 {
-			t.Errorf("Expected 0 results recieved %d", len(results))
+			t.Errorf("When body is empty it should perform a request")
 		}
 	})
 
-	t.Run("Successful Response", func(t *testing.T) {
+	t.Run("Should invoke all functions", func(t *testing.T) {
 		target := &Invoker{
 			true,
 			client,
 			srv.URL,
 		}
 
-		body := []byte("Body")
-		results := target.Invoke(&topicMap, "Success", &body)
+		body := []byte("Some Input")
+		results := target.Invoke(&topicMap, "All", &body)
 
-		if len(results) != 1 {
-			t.Errorf("Expected 1 results recieved %d", len(results))
+		const ExpectedResults = 3
+		if len(results) != ExpectedResults {
+			t.Errorf("Expected %d results recieved %d", ExpectedResults, len(results))
 		}
 
-		result := results["200"]
+		for name, result := range results {
+			if result.Error != nil {
+				t.Errorf("Received unexpected error %s for %s", result.Error, name)
+			}
 
-		if result.Error != nil {
-			t.Errorf("Recieved unexpected error %s", result.Error)
+			if result.StatusCode != 200 && result.StatusCode != 400 {
+				t.Errorf("Received unexpected status code %d for %s", result.StatusCode, name)
+			}
 		}
 
-		if result.StatusCode != 200 {
-			t.Errorf("Expected Statuscode 200 recieved %d", result.StatusCode)
-		}
-
-		expected := []byte("Hello World")
-		if !bytes.Equal(expected, *result.Body) {
-			t.Errorf("Expected %s as body recieved %s", expected, *result.Body)
-		}
 	})
 
-	t.Run("Unauthorized Response", func(t *testing.T) {
+	t.Run("Should invoke all functions even if one request fails", func(t *testing.T) {
 		target := &Invoker{
 			true,
 			client,
 			srv.URL,
 		}
 
-		body := []byte("Body")
-		results := target.Invoke(&topicMap, "UnAuthorized", &body)
+		body := []byte("Hello World")
+		results := target.Invoke(&topicMap, "Contains_Fail", &body)
 
-		if len(results) != 1 {
-			t.Errorf("Expected 1 results recieved %d", len(results))
+		const ExpectedResults = 4
+		if len(results) != ExpectedResults {
+			t.Errorf("Expected %d results recieved %d", ExpectedResults, len(results))
 		}
 
-		result := results["401"]
-
-		if result.Error != nil {
-			t.Errorf("Recieved unexpected error %s", result.Error)
-		}
-
-		if result.StatusCode != 401 {
-			t.Errorf("Expected Statuscode 200 recieved %d", result.StatusCode)
-		}
-
-		expected := []byte("")
-		if !bytes.Equal(expected, *result.Body) {
-			t.Errorf("Expected %s as body recieved %s", expected, *result.Body)
-		}
-	})
-
-	t.Run("Server Error Response", func(t *testing.T) {
-		target := &Invoker{
-			true,
-			client,
-			srv.URL,
-		}
-
-		body := []byte("Body")
-		results := target.Invoke(&topicMap, "Internal Error", &body)
-
-		if len(results) != 1 {
-			t.Errorf("Expected 1 results recieved %d", len(results))
-		}
-
-		result := results["500"]
-
-		if result.Error != nil {
-			t.Errorf("Recieved unexpected error %s", result.Error)
-		}
-
-		if result.StatusCode != 500 {
-			t.Errorf("Expected Statuscode 200 recieved %d", result.StatusCode)
-		}
-
-		expected := []byte("")
-		if !bytes.Equal(expected, *result.Body) {
-			t.Errorf("Expected %s as body recieved %s", expected, *result.Body)
+		for name, result := range results {
+			if name == "aborts" {
+				if result.Error == nil {
+					t.Errorf("Expected call for %s to fail", name)
+				}
+			} else {
+				if result.Error != nil {
+					t.Errorf("Received unexpected error %s for %s", result.Error, name)
+				}
+			}
 		}
 	})
 }

--- a/types/invoker_test.go
+++ b/types/invoker_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) OpenFaaS Project 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestInvoker_Invoke(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		function := strings.Split(r.URL.Path, "/")[2]
+
+		switch function {
+		case "200":
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(200)
+			w.Write([]byte("Hello World"))
+		case "401":
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(401)
+			w.Write([]byte(""))
+		case "500":
+		}
+		w.WriteHeader(500)
+	}))
+	client := srv.Client()
+	topicMap := NewTopicMap()
+	sampleFunc := map[string][]string{
+		"Success":        []string{"200"},
+		"UnAuthorized":   []string{"401"},
+		"Internal Error": []string{"500"},
+	}
+	topicMap.Sync(&sampleFunc)
+
+	t.Run("Empty Body", func(t *testing.T) {
+		target := &Invoker{
+			true,
+			client,
+			srv.URL,
+		}
+
+		body := []byte("")
+		results := target.Invoke(&topicMap, "Success", &body)
+
+		if len(results) != 0 {
+			t.Errorf("Expected 0 results recieved %d", len(results))
+		}
+	})
+
+	t.Run("Successful Response", func(t *testing.T) {
+		target := &Invoker{
+			true,
+			client,
+			srv.URL,
+		}
+
+		body := []byte("Body")
+		results := target.Invoke(&topicMap, "Success", &body)
+
+		if len(results) != 1 {
+			t.Errorf("Expected 1 results recieved %d", len(results))
+		}
+
+		result := results["200"]
+
+		if result.Error != nil {
+			t.Errorf("Recieved unexpected error %s", result.Error)
+		}
+
+		if result.StatusCode != 200 {
+			t.Errorf("Expected Statuscode 200 recieved %d", result.StatusCode)
+		}
+
+		expected := []byte("Hello World")
+		if !bytes.Equal(expected, *result.Body) {
+			t.Errorf("Expected %s as body recieved %s", expected, *result.Body)
+		}
+	})
+
+	t.Run("Unauthorized Response", func(t *testing.T) {
+		target := &Invoker{
+			true,
+			client,
+			srv.URL,
+		}
+
+		body := []byte("Body")
+		results := target.Invoke(&topicMap, "UnAuthorized", &body)
+
+		if len(results) != 1 {
+			t.Errorf("Expected 1 results recieved %d", len(results))
+		}
+
+		result := results["401"]
+
+		if result.Error != nil {
+			t.Errorf("Recieved unexpected error %s", result.Error)
+		}
+
+		if result.StatusCode != 401 {
+			t.Errorf("Expected Statuscode 200 recieved %d", result.StatusCode)
+		}
+
+		expected := []byte("")
+		if !bytes.Equal(expected, *result.Body) {
+			t.Errorf("Expected %s as body recieved %s", expected, *result.Body)
+		}
+	})
+
+	t.Run("Server Error Response", func(t *testing.T) {
+		target := &Invoker{
+			true,
+			client,
+			srv.URL,
+		}
+
+		body := []byte("Body")
+		results := target.Invoke(&topicMap, "Internal Error", &body)
+
+		if len(results) != 1 {
+			t.Errorf("Expected 1 results recieved %d", len(results))
+		}
+
+		result := results["500"]
+
+		if result.Error != nil {
+			t.Errorf("Recieved unexpected error %s", result.Error)
+		}
+
+		if result.StatusCode != 500 {
+			t.Errorf("Expected Statuscode 200 recieved %d", result.StatusCode)
+		}
+
+		expected := []byte("")
+		if !bytes.Equal(expected, *result.Body) {
+			t.Errorf("Expected %s as body recieved %s", expected, *result.Body)
+		}
+	})
+}


### PR DESCRIPTION
Addresses Feature wishes from #2

**Changes:**
- Invoke Signature changed from `func (i *Invoker) Invoke(topicMap *TopicMap, topic string, message *[]byte)` => `func (i *Invoker) Invoke(topicMap *TopicMap, topic string, message *[]byte) (result map[string]*InvocationResult)`
- Renamed `invokefunction` to `performInvocation` and changed signature to `performInvocation(c *http.Client, gwURL string, reader io.Reader) (err error, statusCode int, responseHeaders http.Header, responseBody *[]byte`
- If `PrintResponse` is true it will now also log the headers

- Added Tests for Invoker covering some cases. Further logs show also the printing of header


Signed-off-by: Simon Pelczer <templum.dev@gmail.com>