### PR TITLE
Receive responses via subscribers

### DIFF
--- a/types/invoker.go
+++ b/types/invoker.go
@@ -7,51 +7,76 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+
+	"github.com/pkg/errors"
 )
 
 type Invoker struct {
 	PrintResponse bool
 	Client        *http.Client
 	GatewayURL    string
+	Responses     chan InvokerResponse
 }
 
+type InvokerResponse struct {
+	Body     *[]byte
+	Header   *http.Header
+	Status   int
+	Error    error
+	Topic    string
+	Function string
+}
+
+func NewInvoker(gatewayURL string, client *http.Client, printResponse bool) *Invoker {
+	return &Invoker{
+		PrintResponse: printResponse,
+		Client:        client,
+		GatewayURL:    gatewayURL,
+		Responses:     make(chan InvokerResponse),
+	}
+}
+
+// Invoke triggers a function by accessing the API Gateway
 func (i *Invoker) Invoke(topicMap *TopicMap, topic string, message *[]byte) {
-	if len(*message) > 0 {
+	if len(*message) == 0 {
+		i.Responses <- InvokerResponse{
+			Error: fmt.Errorf("no message to send"),
+		}
+	}
 
-		matchedFunctions := topicMap.Match(topic)
-		for _, matchedFunction := range matchedFunctions {
+	matchedFunctions := topicMap.Match(topic)
+	for _, matchedFunction := range matchedFunctions {
+		log.Printf("Invoke function: %s", matchedFunction)
 
-			log.Printf("Invoke function: %s", matchedFunction)
+		gwURL := fmt.Sprintf("%s/function/%s", i.GatewayURL, matchedFunction)
+		reader := bytes.NewReader(*message)
 
-			gwURL := fmt.Sprintf("%s/function/%s", i.GatewayURL, matchedFunction)
-			reader := bytes.NewReader(*message)
+		body, statusCode, header, doErr := invokefunction(i.Client, gwURL, reader)
 
-			body, statusCode, doErr := invokefunction(i.Client, gwURL, reader)
-
-			if doErr != nil {
-				log.Printf("Unable to invoke from %s, error: %s\n", matchedFunction, doErr)
-				return
+		if doErr != nil {
+			i.Responses <- InvokerResponse{
+				Error: errors.Wrap(doErr, fmt.Sprintf("unable to invoke %s", matchedFunction)),
 			}
+			continue
+		}
 
-			printBody := false
-			stringOutput := ""
+		// if printBody {
+		// 	log.Printf("Response [%d] from %s %s", statusCode, matchedFunction, stringOutput)
+		// } else {
+		// 	log.Printf("Response [%d] from %s", statusCode, matchedFunction)
+		// }
 
-			if body != nil && i.PrintResponse {
-				stringOutput = string(*body)
-				printBody = true
-			}
-
-			if printBody {
-				log.Printf("Response [%d] from %s %s", statusCode, matchedFunction, stringOutput)
-
-			} else {
-				log.Printf("Response [%d] from %s", statusCode, matchedFunction)
-			}
+		i.Responses <- InvokerResponse{
+			Body:     body,
+			Status:   statusCode,
+			Header:   header,
+			Function: matchedFunction,
+			Topic:    topic,
 		}
 	}
 }
 
-func invokefunction(c *http.Client, gwURL string, reader io.Reader) (*[]byte, int, error) {
+func invokefunction(c *http.Client, gwURL string, reader io.Reader) (*[]byte, int, *http.Header, error) {
 
 	httpReq, _ := http.NewRequest(http.MethodPost, gwURL, reader)
 
@@ -63,7 +88,7 @@ func invokefunction(c *http.Client, gwURL string, reader io.Reader) (*[]byte, in
 
 	res, doErr := c.Do(httpReq)
 	if doErr != nil {
-		return nil, http.StatusServiceUnavailable, doErr
+		return nil, http.StatusServiceUnavailable, nil, doErr
 	}
 
 	if res.Body != nil {
@@ -72,11 +97,11 @@ func invokefunction(c *http.Client, gwURL string, reader io.Reader) (*[]byte, in
 		bytesOut, readErr := ioutil.ReadAll(res.Body)
 		if readErr != nil {
 			log.Printf("Error reading body")
-			return nil, http.StatusServiceUnavailable, doErr
+			return nil, http.StatusServiceUnavailable, nil, doErr
 
 		}
 		body = &bytesOut
 	}
 
-	return body, res.StatusCode, doErr
+	return body, res.StatusCode, &res.Header, doErr
 }

--- a/types/response_printer.go
+++ b/types/response_printer.go
@@ -1,0 +1,19 @@
+package types
+
+import (
+	"log"
+)
+
+// ResponsePrinter prints function results
+type ResponsePrinter struct {
+}
+
+// Response is triggered by the controller when a message is
+// received from the function invocation
+func (rp *ResponsePrinter) Response(res InvokerResponse) {
+	if res.Error != nil {
+		log.Printf("connector-sdk got error: %s", res.Error.Error())
+	} else {
+		log.Printf("connector-sdk got result: [%d] %s => %s (%d) bytes", res.Status, res.Topic, res.Function, len(*res.Body))
+	}
+}


### PR DESCRIPTION
Receive responses via subscribers

- change enables HTTP body, HTTP status, HTTP headers and any
error whilst invoking to be received by 1-many subscribers.
- "print response" behaviour is also moved into a subscriber

Tested with the "tester" example connector.

Example:

```go

// ResponseReceiver enables connector to receive results from the
// function invocation
type ResponseReceiver struct {
}

// Response is triggered by the controller when a message is
// received from the function invocation
func (ResponseReceiver) Response(res types.InvokerResponse) {
	if res.Error != nil {
		log.Printf("tester got error: %s", res.Error.Error())
	} else {
		log.Printf("tester got result: [%d] %s => %s (%d) bytes", res.Status, res.Topic, res.Function, len(*res.Body))
	}
}
```

```go
	receiver := ResponseReceiver{}
	controller.Subscribe(&receiver)
```

Closes: #4 

Signed-off-by: Alex Ellis (VMware) <alexellis2@gmail.com>