### PR TITLE
Add timeout for http.Client

### DIFF
--- a/types/make_client.go
+++ b/types/make_client.go
@@ -6,11 +6,15 @@ import (
 	"time"
 )
 
+// MakeClient returns a http.Client with a timeout for connection establishing and request handling
 func MakeClient(timeout time.Duration) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
+				// Timeout is the maximum amount of time a dial will wait for
+				// a connect to complete. If Deadline is also set, it may fail
+				// earlier.
 				Timeout:   timeout,
 				KeepAlive: 10 * time.Second,
 			}).DialContext,
@@ -18,5 +22,11 @@ func MakeClient(timeout time.Duration) *http.Client {
 			MaxIdleConnsPerHost: 100,
 			IdleConnTimeout:     120 * time.Millisecond,
 		},
+		// Timeout specifies a time limit for requests made by this
+		// Client. The timeout includes connection time, any
+		// redirects, and reading the response body. The timer remains
+		// running after Get, Head, Post, or Do return and will
+		// interrupt reading of the Response.Body.
+		Timeout: timeout,
 	}
 }


### PR DESCRIPTION
- Invoker http.Client now also uses the user-defined upstream
timeout for http requests (before: only net.Dialer used the timeout for
initial connection establishing), see https://godoc.org/net/http#Client
- Similar to how [OpenFaaS http connection handling](https://github.com/openfaas/faas/blob/bfa869ec8c0c04c26c5b0ed434bc367e712dcaef/gateway/types/proxy_client.go#L30) uses the timeout in `http.Client`
- A separate `context.Context` for the [`httpReq`](https://github.com/openfaas-incubator/connector-sdk/blob/d722c9f72ad06903f416d1bc89878ba5a824b227/types/invoker.go#L83) in invoker's `c.Do()` is not needed right now as the underlying http.Client now has a timeout for the request (unless there's need for context.Context)

Signed-off-by: Michael Gasch <embano1@live.com>