### PR TITLE
Add functions to get the current list of topics

### DIFF
--- a/types/controller.go
+++ b/types/controller.go
@@ -134,3 +134,9 @@ func synchronizeLookups(ticker *time.Ticker,
 		topicMap.Sync(&lookups)
 	}
 }
+
+// Topics gets the list of topics that functions have indicated should
+// be used as triggers.
+func (c *Controller) Topics() []string {
+	return c.TopicMap.Topics()
+}

--- a/types/topic_map.go
+++ b/types/topic_map.go
@@ -40,3 +40,15 @@ func (t *TopicMap) Sync(updated *map[string][]string) {
 
 	t.lookup = updated
 }
+
+func (t *TopicMap) Topics() []string {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	topics := make([]string, 0, len(*t.lookup))
+	for topic := range *t.lookup {
+		topics = append(topics, topic)
+	}
+
+	return topics
+}


### PR DESCRIPTION
Resolves #13 

This commit adds a Topics function to bring the TopicMap
implementation in line with that of the Kafka connector. The Topics
function was added to kafka-connector after the connector-sdk was
extracted from it.

It also adds a Topics function to Controller that returns the list
of topics in the TopicMap. This function is added so that connector
implementations can get the list of current topics without having to
knew about the internal structure of Controller.

Signed-off-by: Chad Taylor <taylor.thomas.c@gmail.com>