### PR TITLE
Print newline when printing response body to stdout

### DIFF
--- a/types/response_printer.go
+++ b/types/response_printer.go
@@ -18,7 +18,7 @@ func (rp *ResponsePrinter) Response(res InvokerResponse) {
 	} else {
 		log.Printf("connector-sdk got result: [%d] %s => %s (%d) bytes", res.Status, res.Topic, res.Function, len(*res.Body))
 		if rp.PrintResponseBody {
-			fmt.Printf("[%d] %s => %s\n%q", res.Status, res.Topic, res.Function, string(*res.Body))
+			fmt.Printf("[%d] %s => %s\n%q\n", res.Status, res.Topic, res.Function, string(*res.Body))
 		}
 	}
 }


### PR DESCRIPTION
Resolves #15 

This commit adds a newline at the end of printing the response body to
stdout. This ensures that the message gets flushed correctly and does
not mix the response body of the previous response with the status
information of the current response.

Signed-off-by: Chad Taylor <taylor.thomas.c@gmail.com>