### PR TITLE
Update TopicMap to use RWMutex

### DIFF
--- a/types/topic_map.go
+++ b/types/topic_map.go
@@ -9,18 +9,18 @@ func NewTopicMap() TopicMap {
 	lookup := make(map[string][]string)
 	return TopicMap{
 		lookup: &lookup,
-		lock:   sync.Mutex{},
+		lock:   sync.RWMutex{},
 	}
 }
 
 type TopicMap struct {
 	lookup *map[string][]string
-	lock   sync.Mutex
+	lock   sync.RWMutex
 }
 
 func (t *TopicMap) Match(topicName string) []string {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
 
 	var values []string
 
@@ -42,8 +42,8 @@ func (t *TopicMap) Sync(updated *map[string][]string) {
 }
 
 func (t *TopicMap) Topics() []string {
-	t.lock.Lock()
-	defer t.lock.Unlock()
+	t.lock.RLock()
+	defer t.lock.RUnlock()
 
 	topics := make([]string, 0, len(*t.lookup))
 	for topic := range *t.lookup {


### PR DESCRIPTION
Fixes #17 

This commit updates the TopicMap implementation to use a RWMutex
instead of a Mutex internally. This change offers more clear semantics
as well as a better performance profile for concurrent reads.

Signed-off-by: Chad Taylor <taylor.thomas.c@gmail.com>