### PR TITLE
Enable multiple topics per function

### DIFF
--- a/types/controller.go
+++ b/types/controller.go
@@ -24,6 +24,9 @@ type ControllerConfig struct {
 
 	// RebuildInterval the interval at which the topic map is rebuilt
 	RebuildInterval time.Duration
+
+	// TopicAnnotationDelimiter defines the character upon which to split the Topic annotation value
+	TopicAnnotationDelimiter string
 }
 
 // Controller for the connector SDK
@@ -110,9 +113,10 @@ func (c *Controller) Invoke(topic string, message *[]byte) {
 func (c *Controller) BeginMapBuilder() {
 
 	lookupBuilder := FunctionLookupBuilder{
-		GatewayURL:  c.Config.GatewayURL,
-		Client:      MakeClient(c.Config.UpstreamTimeout),
-		Credentials: c.Credentials,
+		GatewayURL:     c.Config.GatewayURL,
+		Client:         MakeClient(c.Config.UpstreamTimeout),
+		Credentials:    c.Credentials,
+		TopicDelimiter: c.Config.TopicAnnotationDelimiter,
 	}
 
 	ticker := time.NewTicker(c.Config.RebuildInterval)

--- a/types/function_list_builder.go
+++ b/types/function_list_builder.go
@@ -61,7 +61,7 @@ func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
 
 			if topicNames, exist := annotations["topic"]; exist {
 
-				if strings.Count(topicNames, s.TopicDelimiter) > 0 {
+				if len(s.TopicDelimiter) > 0 && strings.Count(topicNames, s.TopicDelimiter) > 0 {
 
 					topicSlice := strings.Split(topicNames, s.TopicDelimiter)
 

--- a/types/function_list_builder.go
+++ b/types/function_list_builder.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 
 	"github.com/openfaas/faas-provider/auth"
 	"github.com/openfaas/faas/gateway/requests"
@@ -55,12 +56,19 @@ func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
 		if function.Annotations != nil {
 			annotations := *function.Annotations
 
-			if topic, pass := annotations["topic"]; pass {
+			if topicCSV, exists := annotations["topic"]; exists {
 
-				if serviceMap[topic] == nil {
-					serviceMap[topic] = []string{}
+				topicSlice := strings.Split(topicCSV, ",")
+
+				for _, topic := range topicSlice {
+
+					topic = strings.TrimSpace(topic)
+
+					if serviceMap[topic] == nil {
+						serviceMap[topic] = []string{}
+					}
+					serviceMap[topic] = append(serviceMap[topic], function.Name)
 				}
-				serviceMap[topic] = append(serviceMap[topic], function.Name)
 			}
 		}
 	}

--- a/types/function_list_builder.go
+++ b/types/function_list_builder.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 
 	"github.com/openfaas/faas-provider/auth"
@@ -17,9 +16,10 @@ import (
 
 // FunctionLookupBuilder builds a list of OpenFaaS functions
 type FunctionLookupBuilder struct {
-	GatewayURL  string
-	Client      *http.Client
-	Credentials *auth.BasicAuthCredentials
+	GatewayURL     string
+	Client         *http.Client
+	Credentials    *auth.BasicAuthCredentials
+	TopicDelimiter string
 }
 
 // Build compiles a map of topic names and functions that have
@@ -53,12 +53,6 @@ func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
 		return serviceMap, marshalErr
 	}
 
-	topicDelim := ","
-
-	if delim, exists := os.LookupEnv("topic_delimiter"); exists && len(delim) > 0 {
-		topicDelim = delim
-	}
-
 	for _, function := range functions {
 
 		if function.Annotations != nil {
@@ -67,9 +61,9 @@ func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
 
 			if topicNames, exist := annotations["topic"]; exist {
 
-				if strings.Count(topicNames, topicDelim) > 0 {
+				if strings.Count(topicNames, s.TopicDelimiter) > 0 {
 
-					topicSlice := strings.Split(topicNames, topicDelim)
+					topicSlice := strings.Split(topicNames, s.TopicDelimiter)
 
 					for _, topic := range topicSlice {
 						serviceMap = appendServiceMap(topic, function.Name, serviceMap)

--- a/types/function_list_builder_test.go
+++ b/types/function_list_builder_test.go
@@ -43,6 +43,37 @@ func TestBuildSingleMatchingFunction(t *testing.T) {
 	}
 }
 
+func TestBuildMultiMatchingFunction(t *testing.T) {
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		functions := []requests.Function{}
+		annotationMap := make(map[string]string)
+		annotationMap["topic"] = "topic1,topic2,topic3"
+
+		functions = append(functions, requests.Function{
+			Name:        "echo",
+			Annotations: &annotationMap,
+		})
+		bytesOut, _ := json.Marshal(functions)
+		w.Write(bytesOut)
+	}))
+
+	client := srv.Client()
+	builder := FunctionLookupBuilder{
+		Client:     client,
+		GatewayURL: srv.URL,
+	}
+
+	lookup, err := builder.Build()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if len(lookup) != 3 {
+		t.Errorf("Lookup - want: %d items, got: %d", 3, len(lookup))
+	}
+}
+
 func TestBuildNoFunctions(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/types/function_list_builder_test.go
+++ b/types/function_list_builder_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/openfaas/faas/gateway/requests"
@@ -31,8 +30,9 @@ func TestBuildSingleMatchingFunction(t *testing.T) {
 
 	client := srv.Client()
 	builder := FunctionLookupBuilder{
-		Client:     client,
-		GatewayURL: srv.URL,
+		Client:         client,
+		GatewayURL:     srv.URL,
+		TopicDelimiter: ",",
 	}
 
 	lookup, err := builder.Build()
@@ -62,8 +62,9 @@ func TestBuildMultiMatchingFunction(t *testing.T) {
 
 	client := srv.Client()
 	builder := FunctionLookupBuilder{
-		Client:     client,
-		GatewayURL: srv.URL,
+		Client:         client,
+		GatewayURL:     srv.URL,
+		TopicDelimiter: ",",
 	}
 
 	lookup, err := builder.Build()
@@ -85,8 +86,9 @@ func TestBuildNoFunctions(t *testing.T) {
 
 	client := srv.Client()
 	builder := FunctionLookupBuilder{
-		Client:     client,
-		GatewayURL: srv.URL,
+		Client:         client,
+		GatewayURL:     srv.URL,
+		TopicDelimiter: ",",
 	}
 
 	lookup, err := builder.Build()
@@ -116,8 +118,9 @@ func Test_Build_JustDelim(t *testing.T) {
 
 	client := srv.Client()
 	builder := FunctionLookupBuilder{
-		Client:     client,
-		GatewayURL: srv.URL,
+		Client:         client,
+		GatewayURL:     srv.URL,
+		TopicDelimiter: ",",
 	}
 
 	lookup, err := builder.Build()
@@ -130,9 +133,6 @@ func Test_Build_JustDelim(t *testing.T) {
 }
 
 func Test_Build_MultiMatchingFunctionBespokeDelim(t *testing.T) {
-
-	os.Setenv("topic_delimiter", "|")
-	defer os.Unsetenv("topic_delimiter")
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
@@ -150,8 +150,9 @@ func Test_Build_MultiMatchingFunctionBespokeDelim(t *testing.T) {
 
 	client := srv.Client()
 	builder := FunctionLookupBuilder{
-		Client:     client,
-		GatewayURL: srv.URL,
+		Client:         client,
+		GatewayURL:     srv.URL,
+		TopicDelimiter: "|",
 	}
 
 	lookup, err := builder.Build()

--- a/types/function_list_builder_test.go
+++ b/types/function_list_builder_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/openfaas/faas/gateway/requests"
@@ -94,5 +95,166 @@ func TestBuildNoFunctions(t *testing.T) {
 	}
 	if len(lookup) != 0 {
 		t.Errorf("Lookup - want: %d items, got: %d", 0, len(lookup))
+	}
+}
+
+func Test_Build_JustDelim(t *testing.T) {
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		functions := []requests.Function{}
+		annotationMap := make(map[string]string)
+		annotationMap["topic"] = ","
+
+		functions = append(functions, requests.Function{
+			Name:        "echo",
+			Annotations: &annotationMap,
+		})
+		bytesOut, _ := json.Marshal(functions)
+		w.Write(bytesOut)
+	}))
+
+	client := srv.Client()
+	builder := FunctionLookupBuilder{
+		Client:     client,
+		GatewayURL: srv.URL,
+	}
+
+	lookup, err := builder.Build()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if len(lookup) != 0 {
+		t.Errorf("Lookup - want: %d items, got: %d", 0, len(lookup))
+	}
+}
+
+func Test_Build_MultiMatchingFunctionBespokeDelim(t *testing.T) {
+
+	os.Setenv("topic_delimiter", "|")
+	defer os.Unsetenv("topic_delimiter")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		functions := []requests.Function{}
+		annotationMap := make(map[string]string)
+		annotationMap["topic"] = "topic1|topic2|topic3,withcomma"
+
+		functions = append(functions, requests.Function{
+			Name:        "echo",
+			Annotations: &annotationMap,
+		})
+		bytesOut, _ := json.Marshal(functions)
+		w.Write(bytesOut)
+	}))
+
+	client := srv.Client()
+	builder := FunctionLookupBuilder{
+		Client:     client,
+		GatewayURL: srv.URL,
+	}
+
+	lookup, err := builder.Build()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if len(lookup) != 3 {
+		t.Errorf("Lookup - want: %d items, got: %d", 3, len(lookup))
+	}
+}
+
+func Test_appendServiceMap(t *testing.T) {
+	var TestCases = []struct {
+		Name               string
+		Key                string
+		Function           string
+		InputServiceMap    map[string][]string
+		ExpectedServiceMap map[string][]string
+	}{
+		{
+			Name:            "Empty starting map - key with length",
+			Key:             "newKey",
+			Function:        "fnName",
+			InputServiceMap: map[string][]string{},
+			ExpectedServiceMap: map[string][]string{
+				"newKey": {"fnName"},
+			},
+		},
+		{
+			Name:               "Empty starting map - zero key length",
+			Key:                "",
+			Function:           "fnName",
+			InputServiceMap:    map[string][]string{},
+			ExpectedServiceMap: map[string][]string{},
+		},
+		{
+			Name:            "Populated starting map - key with length",
+			Key:             "theKey",
+			Function:        "newName",
+			InputServiceMap: map[string][]string{"theKey": {"fnName"}},
+			ExpectedServiceMap: map[string][]string{
+				"theKey": {"fnName", "newName"},
+			},
+		},
+		{
+			Name:            "Populated starting map - zero key length",
+			Key:             "",
+			Function:        "newName",
+			InputServiceMap: map[string][]string{"theKey": {"fnName"}},
+			ExpectedServiceMap: map[string][]string{
+				"theKey": {"fnName"},
+			},
+		},
+		{
+			Name:            "Populated starting map - new key with length",
+			Key:             "newKey",
+			Function:        "newName",
+			InputServiceMap: map[string][]string{"theKey": {"fnName"}},
+			ExpectedServiceMap: map[string][]string{
+				"theKey": {"fnName"},
+				"newKey": {"newName"},
+			},
+		},
+		{
+			Name:            "Populated starting map - existing key new function",
+			Key:             "newKey",
+			Function:        "secondName",
+			InputServiceMap: map[string][]string{"theKey": {"fnName"}, "newKey": {"newName"}},
+			ExpectedServiceMap: map[string][]string{
+				"theKey": {"fnName"},
+				"newKey": {"newName", "secondName"},
+			},
+		},
+	}
+
+	for _, test := range TestCases {
+
+		serviceMap := appendServiceMap(test.Key, test.Function, test.InputServiceMap)
+
+		if len(serviceMap) != len(test.ExpectedServiceMap) {
+			t.Errorf("Testcase %s failed on serviceMap size. want - %d, got - %d", test.Name, len(test.ExpectedServiceMap), len(serviceMap))
+		}
+
+		for key := range serviceMap {
+
+			if _, exists := test.ExpectedServiceMap[key]; !exists {
+				t.Errorf("Testcase %s failed on serviceMap keys. found value - %s doesnt exist in expected", test.Name, key)
+			}
+
+			if len(serviceMap[key]) != len(test.ExpectedServiceMap[key]) {
+				t.Errorf("Testcase %s failed on key slice size. want - %d, got - %d", test.Name, len(test.ExpectedServiceMap[key]), len(serviceMap[key]))
+			}
+
+			lookupMap := make(map[string]bool)
+			for _, fn := range serviceMap[key] {
+				lookupMap[fn] = true
+			}
+
+			for _, v := range test.ExpectedServiceMap[key] {
+				if _, found := lookupMap[v]; !found {
+					t.Errorf("Testcase %s failed on key slice values. found value - %s doesnt exist in expected", test.Name, v)
+				}
+			}
+		}
 	}
 }

--- a/types/function_list_builder_test.go
+++ b/types/function_list_builder_test.go
@@ -43,6 +43,36 @@ func TestBuildSingleMatchingFunction(t *testing.T) {
 		t.Errorf("Lookup - want: %d items, got: %d", 1, len(lookup))
 	}
 }
+func Test_Build_SingleFunctionNoDelimiter(t *testing.T) {
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		functions := []requests.Function{}
+		annotationMap := make(map[string]string)
+		annotationMap["topic"] = "topic1"
+
+		functions = append(functions, requests.Function{
+			Name:        "echo",
+			Annotations: &annotationMap,
+		})
+		bytesOut, _ := json.Marshal(functions)
+		w.Write(bytesOut)
+	}))
+
+	client := srv.Client()
+	builder := FunctionLookupBuilder{
+		Client:     client,
+		GatewayURL: srv.URL,
+	}
+
+	lookup, err := builder.Build()
+	if err != nil {
+		t.Errorf("%s", err)
+	}
+	if len(lookup) != 1 {
+		t.Errorf("Lookup - want: %d items, got: %d", 1, len(lookup))
+	}
+}
 
 func TestBuildMultiMatchingFunction(t *testing.T) {
 


### PR DESCRIPTION
A function’s topic annotation value is a CSV.  The service map should be 1..1 topic to 1..* functions. The connecter SDK currently makes the serviceMap key from the entire annotation value, which means where a CSV has been used in the function annotation value then the serviceMap key will be the full CSV.

This change introduces breaking of the topic annotation CSV using comma as a delimiter so that a function can be mapped to multiple topics.

Fixes #20

Signed-off-by: Richard Gee <richard@technologee.co.uk>