### PR TITLE
Add configurable async route

### DIFF
--- a/types/controller.go
+++ b/types/controller.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"fmt"
 	"log"
 	"sync"
 	"time"
@@ -27,6 +28,9 @@ type ControllerConfig struct {
 
 	// TopicAnnotationDelimiter defines the character upon which to split the Topic annotation value
 	TopicAnnotationDelimiter string
+
+	// AsyncFunctionInvocation if true points to the asynchronous function route
+	AsyncFunctionInvocation bool
 }
 
 // Controller for the connector SDK
@@ -55,7 +59,9 @@ type Controller struct {
 // NewController create a new connector SDK controller
 func NewController(credentials *auth.BasicAuthCredentials, config *ControllerConfig) *Controller {
 
-	invoker := NewInvoker(config.GatewayURL,
+	gatewayFunctionPath := gatewayRoute(config)
+
+	invoker := NewInvoker(gatewayFunctionPath,
 		MakeClient(config.UpstreamTimeout),
 		config.PrintResponse)
 
@@ -143,4 +149,11 @@ func synchronizeLookups(ticker *time.Ticker,
 // be used as triggers.
 func (c *Controller) Topics() []string {
 	return c.TopicMap.Topics()
+}
+
+func gatewayRoute(config *ControllerConfig) string {
+	if config.AsyncFunctionInvocation == true {
+		return fmt.Sprintf("%s/%s", config.GatewayURL, "async-function")
+	}
+	return fmt.Sprintf("%s/%s", config.GatewayURL, "function")
 }

--- a/types/invoker.go
+++ b/types/invoker.go
@@ -48,7 +48,7 @@ func (i *Invoker) Invoke(topicMap *TopicMap, topic string, message *[]byte) {
 	for _, matchedFunction := range matchedFunctions {
 		log.Printf("Invoke function: %s", matchedFunction)
 
-		gwURL := fmt.Sprintf("%s/function/%s", i.GatewayURL, matchedFunction)
+		gwURL := fmt.Sprintf("%s/%s", i.GatewayURL, matchedFunction)
 		reader := bytes.NewReader(*message)
 
 		body, statusCode, header, doErr := invokefunction(i.Client, gwURL, reader)


### PR DESCRIPTION
Adding AsyncFunctionInvocation variable in the
ControllerConfig in order to enable/disable
asynchronous invokation of functions along
with augmenting on how we build the gateway
URL

Vendored change can be tested in kafka-connector by augmenting the image with mine:
`martindekov/kafka-connector:0.3.5`
and adding environmental variable `asynchronous_invocation` to `true`/`false` or `1`/`0` for true in the `connector-dep.yml` file

Closes #1 

Tested by vendoring the change in the kafka-connector and invoking function
through the asynchronous path, the output in the kafka-connector looks like this:
```
2019/06/10 13:24:11 Syncing topic map
[#1] Received on [faas-request,0]: 'asdf'
2019/06/10 13:24:12 Invoke function: figlet
2019/06/10 13:24:12 connector-sdk got result: [202] faas-request => figlet (0) bytes
[202] faas-request => figlet

```

Signed-off-by: Martin Dekov <mdekov@vmware.com>