### PR TITLE
Add an option to control log verbosity.

### DIFF
--- a/types/invoker.go
+++ b/types/invoker.go
@@ -16,6 +16,7 @@ type Invoker struct {
 	Client        *http.Client
 	GatewayURL    string
 	Responses     chan InvokerResponse
+	Debug         bool
 }
 
 type InvokerResponse struct {
@@ -27,12 +28,13 @@ type InvokerResponse struct {
 	Function string
 }
 
-func NewInvoker(gatewayURL string, client *http.Client, printResponse bool) *Invoker {
+func NewInvoker(gatewayURL string, client *http.Client, printResponse bool, debug bool) *Invoker {
 	return &Invoker{
 		PrintResponse: printResponse,
 		Client:        client,
 		GatewayURL:    gatewayURL,
 		Responses:     make(chan InvokerResponse),
+		Debug:         debug,
 	}
 }
 
@@ -46,7 +48,9 @@ func (i *Invoker) Invoke(topicMap *TopicMap, topic string, message *[]byte) {
 
 	matchedFunctions := topicMap.Match(topic)
 	for _, matchedFunction := range matchedFunctions {
-		log.Printf("Invoke function: %s", matchedFunction)
+		if i.Debug {
+			log.Printf("Invoke function: %s", matchedFunction)
+		}
 
 		gwURL := fmt.Sprintf("%s/%s", i.GatewayURL, matchedFunction)
 		reader := bytes.NewReader(*message)


### PR DESCRIPTION
Connectors built using the SDK are IMHO a bit too verbose:

```
(...)
2019/08/08 14:16:02 Syncing topic map
2019/08/08 14:16:03 Syncing topic map
2019/08/08 14:16:04 Syncing topic map
2019/08/08 14:16:05 Syncing topic map
2019/08/08 14:16:05 Invoke function: figlet
2019/08/08 14:16:06 Syncing topic map
2019/08/08 14:16:07 Syncing topic map
2019/08/08 14:16:07 Invoke function: figlet
(...)
```

Besides looking like logging statements that are only useful during development (both of applications and of the SDK itself), I can see this quickly becoming a problem in busy environments. Hence I am adding an option to allow developers to decrease the verbosity.

As a side note, a better approach would of course be to use a logging library such as [logrus](https://github.com/sirupsen/logrus), but I see that https://github.com/openfaas/faas/issues/572 still didn't yield a conclusion on which to use.