### PR TITLE
Immediately sync the topic map.

### DIFF
--- a/types/controller.go
+++ b/types/controller.go
@@ -124,7 +124,6 @@ func (c *Controller) InvokeWithContext(ctx context.Context, topic string, messag
 // BeginMapBuilder begins to build a map of function->topic by
 // querying the API gateway.
 func (c *Controller) BeginMapBuilder() {
-
 	lookupBuilder := FunctionLookupBuilder{
 		GatewayURL:     c.Config.GatewayURL,
 		Client:         MakeClient(c.Config.UpstreamTimeout),
@@ -140,15 +139,19 @@ func synchronizeLookups(ticker *time.Ticker,
 	lookupBuilder *FunctionLookupBuilder,
 	topicMap *TopicMap) {
 
-	for {
-		<-ticker.C
+	fn := func() {
 		lookups, err := lookupBuilder.Build()
 		if err != nil {
 			log.Fatalln(err)
 		}
-
 		log.Println("Syncing topic map")
 		topicMap.Sync(&lookups)
+	}
+
+	fn()
+	for {
+		<-ticker.C
+		fn()
 	}
 }
 


### PR DESCRIPTION
Turns out that calling `BeginMapBuilder` doesn't immediately start syncing the topic map, rather waiting until the first "rebuild interval" elapses to start doing that. This may not be entirely noticeable for small values of "rebuild interval", but if this is set to 30 seconds, for instance, that means no function invocations will occur during the first 30 seconds of execution. This PR changes this behaviour so that the first synchronisation happens right after calling `BeginMapBuilder`.