### PR TITLE
Fix bad merge and bad commit to 'master'.

### DIFF
--- a/types/controller.go
+++ b/types/controller.go
@@ -76,8 +76,7 @@ func NewController(credentials *auth.BasicAuthCredentials, config *ControllerCon
 
 	invoker := NewInvoker(gatewayFunctionPath,
 		MakeClient(config.UpstreamTimeout),
-		config.PrintResponse,
-		config.PrintSync)
+		config.PrintResponse)
 
 	subs := []ResponseSubscriber{}
 
@@ -136,12 +135,7 @@ func (c *controller) InvokeWithContext(ctx context.Context, topic string, messag
 
 // BeginMapBuilder begins to build a map of function->topic by
 // querying the API gateway.
-<<<<<<< HEAD
-func (c *Controller) BeginMapBuilder() {
-=======
 func (c *controller) BeginMapBuilder() {
-
->>>>>>> controller-interface
 	lookupBuilder := FunctionLookupBuilder{
 		GatewayURL:     c.Config.GatewayURL,
 		Client:         MakeClient(c.Config.UpstreamTimeout),
@@ -153,7 +147,7 @@ func (c *controller) BeginMapBuilder() {
 	go c.synchronizeLookups(ticker, &lookupBuilder, c.TopicMap)
 }
 
-func (c *Controller) synchronizeLookups(ticker *time.Ticker,
+func (c *controller) synchronizeLookups(ticker *time.Ticker,
 	lookupBuilder *FunctionLookupBuilder,
 	topicMap *TopicMap) {
 


### PR DESCRIPTION
Follow-up to #33. It also seems that https://github.com/openfaas-incubator/connector-sdk/commit/ac35b633765e95e6a2e9e53123ec101f185bf4da removed the `debug` argument from `NewInvoker` while keeping `PrintSync` in a call to `NewInvoker`. I think that CI should be set up for this project to avoid this kind of issues in the future.