### PR TITLE
Use value semantics for sync.Mutex

### DIFF
--- a/types/controller.go
+++ b/types/controller.go
@@ -66,7 +66,7 @@ type controller struct {
 	Subscribers []ResponseSubscriber
 
 	// Lock used for synchronizing subscribers
-	Lock *sync.RWMutex
+	Lock sync.RWMutex
 }
 
 // NewController create a new connector SDK controller
@@ -88,7 +88,6 @@ func NewController(credentials *auth.BasicAuthCredentials, config *ControllerCon
 		TopicMap:    &topicMap,
 		Credentials: credentials,
 		Subscribers: subs,
-		Lock:        &sync.RWMutex{},
 	}
 
 	if config.PrintResponse {


### PR DESCRIPTION
The Go convention is to use value semantics for `sync.Mutex`.
`sync.Mutex` can be directly used without initialization.

When passing the controller to functions, pointer semantics are required
(go vet will catch this). Since all methods on `controller` are pointer
receivers, no further changes are required.

Signed-off-by: Michael Gasch <mgasch@vmware.com>