### PR TITLE
Consistent use of log.Fatal instead of panic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 connector
 kafka-connector
 tester
+.vscode

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:f74e36b9c7f0fcf4d73483a71d873672ebc8a309c57c273af7e11f6f4e32654e"
+  name = "github.com/openfaas-incubator/connector-sdk"
+  packages = ["types"]
+  pruneopts = "UT"
+  revision = "193b73292e32864286853efeccbc5190b5d3c84d"
+  version = "0.5.3"
+
+[[projects]]
   digest = "1:63153ec3ac1c4e93e615b6f5b271a35ad8ced327eba70530903edac0b1f3e652"
   name = "github.com/openfaas/faas-provider"
   packages = [
@@ -24,6 +32,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/openfaas-incubator/connector-sdk/types",
     "github.com/openfaas/faas-provider/auth",
     "github.com/openfaas/faas-provider/types",
     "github.com/pkg/errors",

--- a/vendor/github.com/openfaas-incubator/connector-sdk/LICENSE
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2017-2018 Alex Ellis
+Copyright (c) 2017-2018 OpenFaaS Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/controller.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/controller.go
@@ -1,0 +1,186 @@
+package types
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/openfaas/faas-provider/auth"
+)
+
+// ControllerConfig configures a connector SDK controller
+type ControllerConfig struct {
+	// UpstreamTimeout controls maximum timeout invoking a function via the gateway
+	UpstreamTimeout time.Duration
+
+	//  GatewayURL is the remote OpenFaaS gateway
+	GatewayURL string
+
+	// PrintResponse if true prints the function responses
+	PrintResponse bool
+
+	// PrintResponseBody if true prints the function response body to stdout
+	PrintResponseBody bool
+
+	// RebuildInterval the interval at which the topic map is rebuilt
+	RebuildInterval time.Duration
+
+	// TopicAnnotationDelimiter defines the character upon which to split the Topic annotation value
+	TopicAnnotationDelimiter string
+
+	// AsyncFunctionInvocation if true points to the asynchronous function route
+	AsyncFunctionInvocation bool
+
+	// PrintSync indicates whether the sync should be logged.
+	PrintSync bool
+}
+
+// Controller is used to invoke functions on a per-topic basis and to subscribe to responses returned by said functions.
+type Controller interface {
+	Subscribe(subscriber ResponseSubscriber)
+	Invoke(topic string, message *[]byte)
+	InvokeWithContext(ctx context.Context, topic string, message *[]byte)
+	BeginMapBuilder()
+	Topics() []string
+}
+
+// controller is the default implementation of the Controller interface.
+type controller struct {
+	// Config for the controller
+	Config *ControllerConfig
+
+	// Invoker to invoke functions via HTTP(s)
+	Invoker *Invoker
+
+	// Map of which functions subscribe to which topics
+	TopicMap *TopicMap
+
+	// Credentials to access gateway
+	Credentials *auth.BasicAuthCredentials
+
+	// Subscribers which can receive messages from invocations.
+	// See note on ResponseSubscriber interface about blocking/long-running
+	// operations
+	Subscribers []ResponseSubscriber
+
+	// Lock used for synchronizing subscribers
+	Lock *sync.RWMutex
+}
+
+// NewController create a new connector SDK controller
+func NewController(credentials *auth.BasicAuthCredentials, config *ControllerConfig) Controller {
+
+	gatewayFunctionPath := gatewayRoute(config)
+
+	invoker := NewInvoker(gatewayFunctionPath,
+		MakeClient(config.UpstreamTimeout),
+		config.PrintResponse)
+
+	subs := []ResponseSubscriber{}
+
+	topicMap := NewTopicMap()
+
+	c := controller{
+		Config:      config,
+		Invoker:     invoker,
+		TopicMap:    &topicMap,
+		Credentials: credentials,
+		Subscribers: subs,
+		Lock:        &sync.RWMutex{},
+	}
+
+	if config.PrintResponse {
+		// printer := &{}
+		c.Subscribe(&ResponsePrinter{config.PrintResponseBody})
+	}
+
+	go func(ch *chan InvokerResponse, controller *controller) {
+		for {
+			res := <-*ch
+
+			controller.Lock.RLock()
+			for _, sub := range controller.Subscribers {
+				sub.Response(res)
+			}
+			controller.Lock.RUnlock()
+		}
+	}(&invoker.Responses, &c)
+
+	return &c
+}
+
+// Subscribe adds a ResponseSubscriber to the list of subscribers
+// which receive messages upon function invocation or error
+// Note: it is not possible to Unsubscribe at this point using
+// the API of the controller
+func (c *controller) Subscribe(subscriber ResponseSubscriber) {
+	c.Lock.Lock()
+	defer c.Lock.Unlock()
+	c.Subscribers = append(c.Subscribers, subscriber)
+}
+
+// Invoke attempts to invoke any functions which match the
+// topic the incoming message was published on.
+func (c *controller) Invoke(topic string, message *[]byte) {
+	c.InvokeWithContext(context.Background(), topic, message)
+}
+
+// InvokeWithContext attempts to invoke any functions which match the topic
+// the incoming message was published on while propagating context.
+func (c *controller) InvokeWithContext(ctx context.Context, topic string, message *[]byte) {
+	c.Invoker.InvokeWithContext(ctx, c.TopicMap, topic, message)
+}
+
+// BeginMapBuilder begins to build a map of function->topic by
+// querying the API gateway.
+func (c *controller) BeginMapBuilder() {
+
+	lookupBuilder := FunctionLookupBuilder{
+		GatewayURL:     c.Config.GatewayURL,
+		Client:         MakeClient(c.Config.UpstreamTimeout),
+		Credentials:    c.Credentials,
+		TopicDelimiter: c.Config.TopicAnnotationDelimiter,
+	}
+
+	ticker := time.NewTicker(c.Config.RebuildInterval)
+	go c.synchronizeLookups(ticker, &lookupBuilder, c.TopicMap)
+}
+
+func (c *controller) synchronizeLookups(ticker *time.Ticker,
+	lookupBuilder *FunctionLookupBuilder,
+	topicMap *TopicMap) {
+
+	fn := func() {
+		lookups, err := lookupBuilder.Build()
+		if err != nil {
+			log.Fatalln(err)
+		}
+
+		if c.Config.PrintSync {
+			log.Println("Syncing topic map")
+		}
+
+		topicMap.Sync(&lookups)
+	}
+
+	fn()
+	for {
+		<-ticker.C
+		fn()
+	}
+}
+
+// Topics gets the list of topics that functions have indicated should
+// be used as triggers.
+func (c *controller) Topics() []string {
+	return c.TopicMap.Topics()
+}
+
+func gatewayRoute(config *ControllerConfig) string {
+	if config.AsyncFunctionInvocation == true {
+		return fmt.Sprintf("%s/%s", config.GatewayURL, "async-function")
+	}
+	return fmt.Sprintf("%s/%s", config.GatewayURL, "function")
+}

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/credentials.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/credentials.go
@@ -1,17 +1,11 @@
 package types
 
 import (
-	"log"
 	"os"
 
 	"github.com/openfaas/faas-provider/auth"
 )
 
-// GetCredentials returns a pointer to basic auth credentials using environment
-// variable lookup for runtime secrets retrieved via "secret_mount_path"
-// environment variable.
-//
-// It panics if credentials cannot be retrieved.
 func GetCredentials() *auth.BasicAuthCredentials {
 	var credentials *auth.BasicAuthCredentials
 
@@ -26,7 +20,7 @@ func GetCredentials() *auth.BasicAuthCredentials {
 
 			res, err := reader.Read()
 			if err != nil {
-				log.Fatalln(err)
+				panic(err)
 			}
 			credentials = res
 		}

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/function_list_builder.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/function_list_builder.go
@@ -1,0 +1,182 @@
+// Copyright (c) OpenFaaS Project 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/openfaas/faas-provider/auth"
+	"github.com/openfaas/faas-provider/types"
+	"github.com/pkg/errors"
+)
+
+// FunctionLookupBuilder builds a list of OpenFaaS functions
+type FunctionLookupBuilder struct {
+	GatewayURL     string
+	Client         *http.Client
+	Credentials    *auth.BasicAuthCredentials
+	TopicDelimiter string
+}
+
+//getNamespaces get openfaas namespaces
+func (s *FunctionLookupBuilder) getNamespaces() ([]string, error) {
+	var (
+		err        error
+		namespaces []string
+	)
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/system/namespaces", s.GatewayURL), nil)
+	if err != nil {
+		return namespaces, err
+	}
+
+	if s.Credentials != nil {
+		req.SetBasicAuth(s.Credentials.User, s.Credentials.Password)
+	}
+
+	res, err := s.Client.Do(req)
+	if err != nil {
+		return namespaces, err
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	if res.StatusCode != http.StatusNotFound {
+		bytesOut, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return namespaces, err
+		}
+
+		err = json.Unmarshal(bytesOut, &namespaces)
+		if err != nil {
+			return namespaces, err
+		}
+	}
+
+	return namespaces, err
+}
+
+func (s *FunctionLookupBuilder) getFunctions(namespace string) ([]types.FunctionStatus, error) {
+	gateway := fmt.Sprintf("%s/system/functions", s.GatewayURL)
+	gatewayURL, err := url.Parse(gateway)
+	if err != nil {
+		return []types.FunctionStatus{}, fmt.Errorf("invalid gateway URL: %s", err.Error())
+	}
+	if len(namespace) > 0 {
+		query := gatewayURL.Query()
+		query.Set("namespace", namespace)
+		gatewayURL.RawQuery = query.Encode()
+	}
+
+	req, _ := http.NewRequest(http.MethodGet, gatewayURL.String(), nil)
+	if s.Credentials != nil {
+		req.SetBasicAuth(s.Credentials.User, s.Credentials.Password)
+	}
+
+	res, reqErr := s.Client.Do(req)
+
+	if reqErr != nil {
+		return []types.FunctionStatus{}, reqErr
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	bytesOut, _ := ioutil.ReadAll(res.Body)
+
+	functions := []types.FunctionStatus{}
+	marshalErr := json.Unmarshal(bytesOut, &functions)
+
+	if marshalErr != nil {
+		return []types.FunctionStatus{}, errors.Wrap(marshalErr, fmt.Sprintf("unable to unmarshal value: %q", string(bytesOut)))
+	}
+
+	return functions, nil
+}
+
+// Build compiles a map of topic names and functions that have
+// advertised to receive messages on said topic
+func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
+	var (
+		err error
+	)
+
+	namespaces, err := s.getNamespaces()
+	if err != nil {
+		return map[string][]string{}, err
+	}
+	serviceMap := make(map[string][]string)
+
+	if len(namespaces) == 0 {
+		namespace := ""
+		functions, err := s.getFunctions(namespace)
+		if err != nil {
+			return map[string][]string{}, err
+		}
+		serviceMap = buildServiceMap(&functions, s.TopicDelimiter, namespace, serviceMap)
+	} else {
+		for _, namespace := range namespaces {
+			functions, err := s.getFunctions(namespace)
+			if err != nil {
+				return map[string][]string{}, err
+			}
+			serviceMap = buildServiceMap(&functions, s.TopicDelimiter, namespace, serviceMap)
+		}
+	}
+
+	return serviceMap, err
+}
+
+func buildServiceMap(functions *[]types.FunctionStatus, topicDelimiter, namespace string, serviceMap map[string][]string) map[string][]string {
+	for _, function := range *functions {
+
+		if function.Annotations != nil {
+
+			annotations := *function.Annotations
+
+			if topicNames, exist := annotations["topic"]; exist {
+
+				if len(topicDelimiter) > 0 && strings.Count(topicNames, topicDelimiter) > 0 {
+
+					topicSlice := strings.Split(topicNames, topicDelimiter)
+
+					for _, topic := range topicSlice {
+						serviceMap = appendServiceMap(topic, function.Name, namespace, serviceMap)
+					}
+				} else {
+					serviceMap = appendServiceMap(topicNames, function.Name, namespace, serviceMap)
+				}
+			}
+		}
+	}
+	return serviceMap
+}
+
+func appendServiceMap(key, function, namespace string, sm map[string][]string) map[string][]string {
+
+	key = strings.TrimSpace(key)
+
+	if len(key) > 0 {
+
+		if sm[key] == nil {
+			sm[key] = []string{}
+		}
+		sep := ""
+		if len(namespace) > 0 {
+			sep = "."
+		}
+
+		functionPath := fmt.Sprintf("%s%s%s", function, sep, namespace)
+		sm[key] = append(sm[key], functionPath)
+	}
+
+	return sm
+}

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/invoker.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/invoker.go
@@ -1,0 +1,112 @@
+package types
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+type Invoker struct {
+	PrintResponse bool
+	Client        *http.Client
+	GatewayURL    string
+	Responses     chan InvokerResponse
+}
+
+type InvokerResponse struct {
+	Context  context.Context
+	Body     *[]byte
+	Header   *http.Header
+	Status   int
+	Error    error
+	Topic    string
+	Function string
+}
+
+func NewInvoker(gatewayURL string, client *http.Client, printResponse bool) *Invoker {
+	return &Invoker{
+		PrintResponse: printResponse,
+		Client:        client,
+		GatewayURL:    gatewayURL,
+		Responses:     make(chan InvokerResponse),
+	}
+}
+
+// Invoke triggers a function by accessing the API Gateway
+func (i *Invoker) Invoke(topicMap *TopicMap, topic string, message *[]byte) {
+	i.InvokeWithContext(context.Background(), topicMap, topic, message)
+}
+
+//InvokeWithContext triggers a function by accessing the API Gateway while propagating context
+func (i *Invoker) InvokeWithContext(ctx context.Context, topicMap *TopicMap, topic string, message *[]byte) {
+	if len(*message) == 0 {
+		i.Responses <- InvokerResponse{
+			Context: ctx,
+			Error:   fmt.Errorf("no message to send"),
+		}
+	}
+
+	matchedFunctions := topicMap.Match(topic)
+	for _, matchedFunction := range matchedFunctions {
+		log.Printf("Invoke function: %s", matchedFunction)
+
+		gwURL := fmt.Sprintf("%s/%s", i.GatewayURL, matchedFunction)
+		reader := bytes.NewReader(*message)
+
+		body, statusCode, header, doErr := invokefunction(ctx, i.Client, gwURL, reader)
+
+		if doErr != nil {
+			i.Responses <- InvokerResponse{
+				Context: ctx,
+				Error:   errors.Wrap(doErr, fmt.Sprintf("unable to invoke %s", matchedFunction)),
+			}
+			continue
+		}
+
+		i.Responses <- InvokerResponse{
+			Context:  ctx,
+			Body:     body,
+			Status:   statusCode,
+			Header:   header,
+			Function: matchedFunction,
+			Topic:    topic,
+		}
+	}
+}
+
+func invokefunction(ctx context.Context, c *http.Client, gwURL string, reader io.Reader) (*[]byte, int, *http.Header, error) {
+
+	httpReq, _ := http.NewRequest(http.MethodPost, gwURL, reader)
+	httpReq.WithContext(ctx)
+
+	if httpReq.Body != nil {
+		defer httpReq.Body.Close()
+	}
+
+	var body *[]byte
+
+	res, doErr := c.Do(httpReq)
+	if doErr != nil {
+		return nil, http.StatusServiceUnavailable, nil, doErr
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+
+		bytesOut, readErr := ioutil.ReadAll(res.Body)
+		if readErr != nil {
+			log.Printf("Error reading body")
+			return nil, http.StatusServiceUnavailable, nil, doErr
+
+		}
+		body = &bytesOut
+	}
+
+	return body, res.StatusCode, &res.Header, doErr
+}

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/make_client.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/make_client.go
@@ -1,0 +1,32 @@
+package types
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+// MakeClient returns a http.Client with a timeout for connection establishing and request handling
+func MakeClient(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				// Timeout is the maximum amount of time a dial will wait for
+				// a connect to complete. If Deadline is also set, it may fail
+				// earlier.
+				Timeout:   timeout,
+				KeepAlive: 10 * time.Second,
+			}).DialContext,
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 100,
+			IdleConnTimeout:     120 * time.Millisecond,
+		},
+		// Timeout specifies a time limit for requests made by this
+		// Client. The timeout includes connection time, any
+		// redirects, and reading the response body. The timer remains
+		// running after Get, Head, Post, or Do return and will
+		// interrupt reading of the Response.Body.
+		Timeout: timeout,
+	}
+}

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/response_printer.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/response_printer.go
@@ -1,0 +1,24 @@
+package types
+
+import (
+	"fmt"
+	"log"
+)
+
+// ResponsePrinter prints function results
+type ResponsePrinter struct {
+	PrintResponseBody bool
+}
+
+// Response is triggered by the controller when a message is
+// received from the function invocation
+func (rp *ResponsePrinter) Response(res InvokerResponse) {
+	if res.Error != nil {
+		log.Printf("connector-sdk got error: %s", res.Error.Error())
+	} else {
+		log.Printf("connector-sdk got result: [%d] %s => %s (%d) bytes", res.Status, res.Topic, res.Function, len(*res.Body))
+		if rp.PrintResponseBody {
+			fmt.Printf("[%d] %s => %s\n%s\n", res.Status, res.Topic, res.Function, string(*res.Body))
+		}
+	}
+}

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/response_subscriber.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/response_subscriber.go
@@ -1,0 +1,12 @@
+package types
+
+// ResponseSubscriber enables connector or another client in connector
+// to receive results from the function invocation.
+// Note: when implementing this interface, you must not perform any
+// costly or high-latency operations, or should off-load them to another
+// go-routine to prevent blocking.
+type ResponseSubscriber interface {
+	// Response is triggered by the controller when a message is
+	// received from the function invocation
+	Response(InvokerResponse)
+}

--- a/vendor/github.com/openfaas-incubator/connector-sdk/types/topic_map.go
+++ b/vendor/github.com/openfaas-incubator/connector-sdk/types/topic_map.go
@@ -1,0 +1,56 @@
+// Copyright (c) OpenFaaS Project 2018. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package types
+
+import (
+	"sync"
+)
+
+func NewTopicMap() TopicMap {
+	lookup := make(map[string][]string)
+	return TopicMap{
+		lookup: &lookup,
+		lock:   sync.RWMutex{},
+	}
+}
+
+type TopicMap struct {
+	lookup *map[string][]string
+	lock   sync.RWMutex
+}
+
+func (t *TopicMap) Match(topicName string) []string {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	var values []string
+
+	for key, val := range *t.lookup {
+		if key == topicName {
+			values = val
+			break
+		}
+	}
+
+	return values
+}
+
+func (t *TopicMap) Sync(updated *map[string][]string) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.lookup = updated
+}
+
+func (t *TopicMap) Topics() []string {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	topics := make([]string, 0, len(*t.lookup))
+	for topic := range *t.lookup {
+		topics = append(topics, topic)
+	}
+
+	return topics
+}


### PR DESCRIPTION
As discussed with @alexellis in #6 the use of log.Fatal is encouraged in
specific cases. However, `GetCredentials` in `types/credentials.go` uses
panic and misses the properly formatted log statement.

This PR:

- replaces `panic` with `log.Fatalln`
- adds a doc comment for the exported function
- syncs Godeps as `dep status` even on master throws `Gopkg.lock is out
of sync with imports and/or Gopkg.toml`

The PR was tested via invoking `./tester` against the most recent
faas-netes after running `make`.

Signed-off-by: Michael Gasch <mgasch@vmware.com>