### PR TITLE
Allow to filter functions based on its namespace

### DIFF
--- a/types/controller.go
+++ b/types/controller.go
@@ -38,6 +38,9 @@ type ControllerConfig struct {
 
 	// PrintSync indicates whether the sync should be logged.
 	PrintSync bool
+
+	// Namespace defines the namespace of the functions to be mapped and invoked. If empty, all namespaces will be used.
+	Namespace string
 }
 
 // Controller is used to invoke functions on a per-topic basis and to subscribe to responses returned by said functions.
@@ -145,6 +148,7 @@ func (c *controller) BeginMapBuilder() {
 		Client:         MakeClient(c.Config.UpstreamTimeout),
 		Credentials:    c.Credentials,
 		TopicDelimiter: c.Config.TopicAnnotationDelimiter,
+		Namespace:      c.Config.Namespace,
 	}
 
 	ticker := time.NewTicker(c.Config.RebuildInterval)

--- a/types/function_list_builder.go
+++ b/types/function_list_builder.go
@@ -111,13 +111,19 @@ func (s *FunctionLookupBuilder) getFunctions(namespace string) ([]types.Function
 // advertised to receive messages on said topic
 func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
 	var (
-		err error
+		err        error
+		namespaces []string
 	)
 
-	namespaces, err := s.getNamespaces()
-	if err != nil {
-		return map[string][]string{}, err
+	if s.Namespace == "" {
+		namespaces, err = s.getNamespaces()
+		if err != nil {
+			return map[string][]string{}, err
+		}
+	} else {
+		namespaces = []string{s.Namespace}
 	}
+
 	serviceMap := make(map[string][]string)
 
 	if len(namespaces) == 0 {
@@ -129,11 +135,6 @@ func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
 		serviceMap = buildServiceMap(&functions, s.TopicDelimiter, namespace, serviceMap)
 	} else {
 		for _, namespace := range namespaces {
-			// If a namespace has been selected, list only the functions from it
-			if s.Namespace != "" && s.Namespace != namespace {
-				continue
-			}
-
 			functions, err := s.getFunctions(namespace)
 			if err != nil {
 				return map[string][]string{}, err

--- a/types/function_list_builder.go
+++ b/types/function_list_builder.go
@@ -22,6 +22,7 @@ type FunctionLookupBuilder struct {
 	Client         *http.Client
 	Credentials    *auth.BasicAuthCredentials
 	TopicDelimiter string
+	Namespace      string
 }
 
 //getNamespaces get openfaas namespaces
@@ -128,6 +129,11 @@ func (s *FunctionLookupBuilder) Build() (map[string][]string, error) {
 		serviceMap = buildServiceMap(&functions, s.TopicDelimiter, namespace, serviceMap)
 	} else {
 		for _, namespace := range namespaces {
+			// If a namespace has been selected, list only the functions from it
+			if s.Namespace != "" && s.Namespace != namespace {
+				continue
+			}
+
 			functions, err := s.getFunctions(namespace)
 			if err != nil {
 				return map[string][]string{}, err


### PR DESCRIPTION
## Description
This pull request adds a `Namespace` field in the `ControllerConfig` struct to enable function filtering by namespace. This way, if a namespace is provided, only functions from that namespace will handled (mapped and, consequently, invoked).

I know contributing guidelines ask to raise a proposal before opening a pull request, but this is a needed feature for me, so I'm sorry for the rush.

## Motivation and Context
In a multi-tenant environment, where there are many namespaces which are supposed to be isolated, the connector is not very useful because it ignores the namespaces the functions are in.

## How Has This Been Tested?
A new test function with two sub-tests has been added to `function_list_builder_test.go` to cover filtering and non-filtering (default) use cases.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
