### PR TITLE
Error Response when no matching functions

### DIFF
--- a/types/invoker.go
+++ b/types/invoker.go
@@ -63,6 +63,13 @@ func (i *Invoker) InvokeWithContext(ctx context.Context, topicMap *TopicMap, top
 	}
 
 	matchedFunctions := topicMap.Match(topic)
+	if len(matchedFunctions) == 0 {
+		i.Responses <- InvokerResponse{
+			Context: ctx,
+			Error:   fmt.Errorf("no functions to invoke"),
+		}
+	}
+
 	for _, matchedFunction := range matchedFunctions {
 		log.Printf("Invoke function: %s", matchedFunction)
 


### PR DESCRIPTION
## Description
Send response to indicate no matching functions are found for the topic.

## Motivation and Context
Currently when invoking a function on a topic with controller.Invoke() and there are no matching functions (probably due to function still being loaded, topic-map not refreshed) there is no way to acknowledge upstream. Consider using amqp which uses manual auto-ack, there is no way to determine the failure and do a negative ack / track such invocation failure.

Fixes issue #61 
- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md))
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label


## How Has This Been Tested?
Performed manual testing and recorded the behaviour. 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [x] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
